### PR TITLE
Extract secret - added: Generation of secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See: http://fastd.readthedocs.org/en/v16/manual/config.html
         peers_dir: '[dirname]'
         peers_limit: maximum number of peers to connect to
     fastd_repository_key: (default: '6664E7BDA6B669881EC52E7516EF3F64CB201D9C')
-    fastd_secret: fastd private key (mandatory)
+    fastd_secret: fastd private key - set to "generate" to trigger initial generation. Default: "generate"
     fastd_secure_handshakes: (default: yes)
     fastd_status_socket: (default: '/tmp/fastd_status')
     pgp_keyserver: (default: 'pool.sks-keyservers.net')

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,4 @@ fastd_repository_key: '6664E7BDA6B669881EC52E7516EF3F64CB201D9C'
 fastd_secure_handshakes: 'yes'
 fastd_status_socket: '/var/log/fastd_status'
 pgp_keyserver: 'pool.sks-keyservers.net'
-
+fastd_secret: 'generate'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,18 @@
   notify: 
   - restart fastd
 
+- name: Create secret-file
+  shell: echo "secret \"$(fastd --generate-key --machine-readable)\";" > /etc/fastd/{{ fastd_interface }}/secret && chmod 600 /etc/fastd/{{ fastd_interface }}/secret
+  args:
+    creates: "/etc/fastd/{{ fastd_interface }}/secret"
+
+- name: Update fastd secret (if defined)
+  when: fastd_secret != 'generate'
+  lineinfile: dest=/etc/fastd/{{ fastd_interface }}/secret regexp='^secret' line='secret "{{ fastd_secret }}";'
+  notify:
+  - restart fastd
+
+
 - name: peers_dirs
   file: >
     path="/etc/fastd/{{ fastd_interface }}/{{ item.value.peers_dir }}"

--- a/templates/fastd.conf.j2
+++ b/templates/fastd.conf.j2
@@ -61,7 +61,7 @@ on verify {{ fastd_on_verify.mode | default('async') }} "{{ fastd_on_verify.comm
 
 pmtu {{ fastd_pmtu }};
 
-secret "{{ fastd_secret }}";
+include "secret";
 secure handshakes {{ fastd_secure_handshakes }};
 
 {% if fastd_status_socket is defined %}


### PR DESCRIPTION
- Mitigate Verpeilung: Move fastd secret to sperate file. Thus avoid exposing the secret when pasting the configuration while discussing issues ;-)
-  fastd secret is generated initially, when `fastd_secret` is set to generate
- Default for `fastd_secret` is 'generate'
